### PR TITLE
Increase `apt-get update` timeout in `SudoSshUbuntuImage`

### DIFF
--- a/src/test/kotlin/com/atlassian/performance/tools/virtualusers/lib/sshubuntu/SudoSshUbuntuImage.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/virtualusers/lib/sshubuntu/SudoSshUbuntuImage.kt
@@ -87,7 +87,7 @@ class SudoSshUbuntuImage(
         )
         val ssh = Ssh(sshHost)
         ssh.newConnection().use {
-            it.execute("apt-get update", Duration.ofSeconds(50))
+            it.execute("apt-get update", Duration.ofMinutes(2))
             it.execute("apt-get install sudo")
         }
         return lambda(SudoSshUbuntuContainer(ssh, ports, ip))


### PR DESCRIPTION
It failed on master 3 times in a row.