### PR TITLE
JPERF-530: Declare `VirtualUserBehavior.maxOverhead`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/virtual-users/compare/release-3.8.0...master
 
+### Added
+- Declare `VirtualUserBehavior.maxOverhead`. Unblock [JPERF-530].
+
+  Virtual Users have one main goal: apply realistic load.
+  But they also have to do auxiliary tasks, like spin up browsers, set up Jira, generate users, flush results to disk.
+  All of these tasks take time and can add up to a significant time overhead.
+  Until now, it was assumed it should fit under 5 minutes.
+  But custom setup actions and user generation can easily break that limit. Therefore it's now set explicitly.
+  It might be used internally to warn, fail fast or otherwise control the VUs.
+  It should be used externally to better inform expected runtime duration, to set up timeouts, progress bars, etc.
+
+[JPERF-530]: https://ecosystem.atlassian.net/browse/JPERF-530
+
 ## [3.8.0] - 2019-07-23
 [3.8.0]: https://github.com/atlassian/virtual-users/compare/release-3.7.0...release-3.8.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/virtualusers/api/config/VirtualUserBehavior.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/virtualusers/api/config/VirtualUserBehavior.kt
@@ -9,7 +9,11 @@ import com.atlassian.performance.tools.virtualusers.api.users.SuppliedUserGenera
 import com.atlassian.performance.tools.virtualusers.api.users.UserGenerator
 import com.atlassian.performance.tools.virtualusers.logs.LogConfiguration
 import org.apache.logging.log4j.core.config.AbstractConfiguration
+import java.time.Duration
 
+/**
+ * @param [maxOverhead] Maximum time to be running, but not applying load.
+ */
 class VirtualUserBehavior private constructor(
     @Deprecated(
         message = "There should be no need to display help from Java API. Read the Javadoc or sources instead."
@@ -17,6 +21,7 @@ class VirtualUserBehavior private constructor(
     internal val help: Boolean,
     internal val scenario: Class<out Scenario>,
     val load: VirtualUserLoad,
+    val maxOverhead: Duration,
     internal val seed: Long,
     internal val diagnosticsLimit: Int,
     internal val browser: Class<out Browser>,
@@ -40,6 +45,7 @@ class VirtualUserBehavior private constructor(
         help = help,
         scenario = scenario,
         load = load,
+        maxOverhead = Duration.ofMinutes(5),
         seed = seed,
         diagnosticsLimit = diagnosticsLimit,
         browser = browser,
@@ -103,6 +109,7 @@ class VirtualUserBehavior private constructor(
         private var scenario: Class<out Scenario>
     ) {
         private var load: VirtualUserLoad = VirtualUserLoad.Builder().build()
+        private var maxOverhead: Duration = Duration.ofMinutes(5)
         private var seed: Long = 12345
         private var diagnosticsLimit: Int = 16
         private var browser: Class<out Browser> = HeadlessChromeBrowser::class.java
@@ -112,6 +119,7 @@ class VirtualUserBehavior private constructor(
 
         fun scenario(scenario: Class<out Scenario>) = apply { this.scenario = scenario }
         fun load(load: VirtualUserLoad) = apply { this.load = load }
+        fun maxOverhead(maxOverhead: Duration) = apply { this.maxOverhead = maxOverhead }
         fun seed(seed: Long) = apply { this.seed = seed }
         fun diagnosticsLimit(diagnosticsLimit: Int) = apply { this.diagnosticsLimit = diagnosticsLimit }
         fun browser(browser: Class<out Browser>) = apply { this.browser = browser }
@@ -135,6 +143,7 @@ class VirtualUserBehavior private constructor(
             scenario = behavior.scenario
         ) {
             load = behavior.load
+            maxOverhead = behavior.maxOverhead
             scenario = behavior.scenario
             diagnosticsLimit = behavior.diagnosticsLimit
             browser = behavior.browser
@@ -148,6 +157,7 @@ class VirtualUserBehavior private constructor(
             help = false,
             scenario = scenario,
             load = load,
+            maxOverhead = maxOverhead,
             seed = seed,
             diagnosticsLimit = diagnosticsLimit,
             browser = browser,


### PR DESCRIPTION
Virtual Users have one main goal: apply realistic load.
But they also have to do auxiliary tasks, like spin up browsers, set up Jira, generate users, flush results to disk.
All of these tasks take time and can add up to a significant time overhead.
Until now, it was assumed it should fit under 5 minutes.
But custom setup actions and user generation can easily break that limit. Therefore it's now set explicitly.
It might be used internally to warn, fail fast or otherwise control the VUs.
It should be used externally to better inform expected runtime duration, to set up timeouts, progress bars, etc.