### PR TITLE
JPERF-705: Remove `DockerClientImpl` workaround

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ configurations.all {
                 "org.testcontainers:selenium" -> useVersion("1.15.0")
                 "javax.annotation:javax.annotation-api" -> useVersion("1.3.2")
                 "javax.xml.bind:jaxb-api" -> useVersion("2.3.1")
-                "org.rnorth.visible-assertions:visible-assertions" -> useVersion("2.1.2")
                 "net.java.dev.jna:jna-platform" -> useVersion("5.2.0")
                 "net.java.dev.jna:jna" -> useVersion("5.2.0")
                 "com.google.guava:guava" -> useVersion(guavaVersion)
@@ -103,16 +102,9 @@ dependencies {
     testCompile("junit:junit:4.12")
     testCompile("org.assertj:assertj-core:3.11.0")
     testCompile("com.atlassian.performance.tools:docker-infrastructure:0.3.3")
-    /*
-     * Transitively pulls in their shaded `DockerClientImpl`.
-     * Gotta hack it this way until any of the following happens:
-     * - they stop shading docker-java-core
-     * - they shade docker-java-core properly
-     * - we stop using testcontainers in docker-infrastructure
-     * - we stop using docker-infrastructure
-     */
-    testCompile("org.testcontainers:testcontainers:1.15.0")
-    testCompile("com.github.docker-java:docker-java-api:3.2.5")
+    listOf("docker-java-api", "docker-java-core", "docker-java-transport-zerodep").forEach { artifact ->
+        testCompile("com.github.docker-java:$artifact:3.2.5")
+    }
     testCompile("com.atlassian.performance.tools:infrastructure:[4.0.0,4.15.0]")
 }
 

--- a/gradle/dependency-locks/testCompile.lockfile
+++ b/gradle/dependency-locks/testCompile.lockfile
@@ -12,7 +12,10 @@ com.atlassian.performance.tools:jvm-tasks:1.1.0
 com.atlassian.performance.tools:ssh:2.3.1
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
+com.fasterxml.jackson.core:jackson-core:2.10.3
+com.fasterxml.jackson.core:jackson-databind:2.10.3
 com.github.docker-java:docker-java-api:3.2.5
+com.github.docker-java:docker-java-core:3.2.5
 com.github.docker-java:docker-java-transport-zerodep:3.2.5
 com.github.docker-java:docker-java-transport:3.2.5
 com.github.stephenc.jcip:jcip-annotations:1.0-1
@@ -29,6 +32,7 @@ com.typesafe:config:1.2.1
 commons-cli:commons-cli:1.4
 commons-codec:commons-codec:1.10
 commons-io:commons-io:2.6
+commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 javax.inject:javax.inject:1

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -12,7 +12,10 @@ com.atlassian.performance.tools:jvm-tasks:1.1.0
 com.atlassian.performance.tools:ssh:2.3.1
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
+com.fasterxml.jackson.core:jackson-core:2.10.3
+com.fasterxml.jackson.core:jackson-databind:2.10.3
 com.github.docker-java:docker-java-api:3.2.5
+com.github.docker-java:docker-java-core:3.2.5
 com.github.docker-java:docker-java-transport-zerodep:3.2.5
 com.github.docker-java:docker-java-transport:3.2.5
 com.github.stephenc.jcip:jcip-annotations:1.0-1
@@ -29,6 +32,7 @@ com.typesafe:config:1.2.1
 commons-cli:commons-cli:1.4
 commons-codec:commons-codec:1.10
 commons-io:commons-io:2.6
+commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 junit:junit:4.12
@@ -60,11 +64,8 @@ org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
 org.jsoup:jsoup:1.10.2
 org.rauschig:jarchivelib:0.7.1
-org.rnorth.duct-tape:duct-tape:1.0.8
-org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.seleniumhq.selenium:selenium-api:3.141.59
 org.seleniumhq.selenium:selenium-chrome-driver:3.141.59
 org.seleniumhq.selenium:selenium-remote-driver:3.141.59
 org.seleniumhq.selenium:selenium-support:3.141.59
 org.slf4j:slf4j-api:1.8.0-alpha2
-org.testcontainers:testcontainers:1.15.0

--- a/gradle/dependency-locks/testRuntime.lockfile
+++ b/gradle/dependency-locks/testRuntime.lockfile
@@ -12,7 +12,10 @@ com.atlassian.performance.tools:jvm-tasks:1.1.0
 com.atlassian.performance.tools:ssh:2.3.1
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
+com.fasterxml.jackson.core:jackson-core:2.10.3
+com.fasterxml.jackson.core:jackson-databind:2.10.3
 com.github.docker-java:docker-java-api:3.2.5
+com.github.docker-java:docker-java-core:3.2.5
 com.github.docker-java:docker-java-transport-zerodep:3.2.5
 com.github.docker-java:docker-java-transport:3.2.5
 com.github.stephenc.jcip:jcip-annotations:1.0-1
@@ -29,6 +32,7 @@ com.typesafe:config:1.2.1
 commons-cli:commons-cli:1.4
 commons-codec:commons-codec:1.10
 commons-io:commons-io:2.6
+commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 javax.inject:javax.inject:1

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -12,7 +12,10 @@ com.atlassian.performance.tools:jvm-tasks:1.1.0
 com.atlassian.performance.tools:ssh:2.3.1
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
+com.fasterxml.jackson.core:jackson-core:2.10.3
+com.fasterxml.jackson.core:jackson-databind:2.10.3
 com.github.docker-java:docker-java-api:3.2.5
+com.github.docker-java:docker-java-core:3.2.5
 com.github.docker-java:docker-java-transport-zerodep:3.2.5
 com.github.docker-java:docker-java-transport:3.2.5
 com.github.stephenc.jcip:jcip-annotations:1.0-1
@@ -29,6 +32,7 @@ com.typesafe:config:1.2.1
 commons-cli:commons-cli:1.4
 commons-codec:commons-codec:1.10
 commons-io:commons-io:2.6
+commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1
 javax.inject:javax.inject:1

--- a/src/test/kotlin/com/atlassian/performance/tools/virtualusers/DockerJiraFormula.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/virtualusers/DockerJiraFormula.kt
@@ -14,7 +14,9 @@ import com.atlassian.performance.tools.virtualusers.lib.infrastructure.SshJiraNo
 import com.atlassian.performance.tools.virtualusers.lib.sshubuntu.SudoSshUbuntuContainer
 import com.atlassian.performance.tools.virtualusers.lib.sshubuntu.SudoSshUbuntuImage
 import com.github.dockerjava.api.model.ExposedPort
-import org.testcontainers.DockerClientFactory
+import com.github.dockerjava.core.DefaultDockerClientConfig
+import com.github.dockerjava.core.DockerClientImpl
+import com.github.dockerjava.zerodep.ZerodepDockerHttpClient
 import java.net.URI
 import java.time.Duration
 
@@ -26,7 +28,9 @@ class DockerJiraFormula(
     fun <T> runWithJira(
         lambda: (DockerJira) -> T
     ): T {
-        val docker = DockerClientFactory.instance().client()
+        val dockerConfig = DefaultDockerClientConfig.createDefaultConfigBuilder().build()
+        val dockerHttp = ZerodepDockerHttpClient.Builder().dockerHost(dockerConfig.dockerHost).build()
+        val docker = DockerClientImpl.getInstance(dockerConfig, dockerHttp)
         return docker
             .createNetworkCmd()
             .withName("shared-network") // copy of com.atlassian.performance.tools.dockerinfrastructure.network.SharedNetwork.DEFAULT_NETWORK_NAME

--- a/src/test/kotlin/com/atlassian/performance/tools/virtualusers/lib/sshubuntu/SudoSshUbuntuImageIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/virtualusers/lib/sshubuntu/SudoSshUbuntuImageIT.kt
@@ -1,16 +1,20 @@
 package com.atlassian.performance.tools.virtualusers.lib.sshubuntu
 
 import com.atlassian.performance.tools.virtualusers.lib.docker.execAsResource
+import com.github.dockerjava.core.DefaultDockerClientConfig
+import com.github.dockerjava.core.DockerClientImpl
+import com.github.dockerjava.zerodep.ZerodepDockerHttpClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.testcontainers.DockerClientFactory
 import java.util.UUID
 
 class SudoSshUbuntuImageIT {
 
     @Test
     fun shouldStartUbuntu() {
-        val docker = DockerClientFactory.instance().client()
+        val dockerConfig = DefaultDockerClientConfig.createDefaultConfigBuilder().build()
+        val dockerHttp = ZerodepDockerHttpClient.Builder().dockerHost(dockerConfig.dockerHost).build()
+        val docker = DockerClientImpl.getInstance(dockerConfig, dockerHttp)
         val osName = docker
             .createNetworkCmd()
             .withName(UUID.randomUUID().toString())


### PR DESCRIPTION
The `testcontainers:*:1.15.0` [fixed shading] of `docker-java-core`.
The dependendency on `testcontainers` is maintained transitively via `docker-infrastructure`.
The last usage of `docker-infrastructure` remains in `ChromeContainer`.
Pure `docker-java-core` is more verbose than the `testcontainers` shade, because the short version is deprecated.

[fixed shading]: https://github.com/atlassian/virtual-users/pull/47/files#r519977022