### PR TITLE
JPERF-709: Include dependency locks in CI cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "build.gradle.kts" }}
-            - v3-dependencies-
+            - v4-dependencies-{{ checksum "build.gradle.kts" }}-{{ checksum "gradle/*" }}
+            - v4-dependencies-
       - run: ./gradlew compileTestKotlin
       - save_cache:
           paths:
             - ~/.gradle
-          key: v3-dependencies-{{ checksum "build.gradle.kts" }}
+          key: v4-dependencies-{{ checksum "build.gradle.kts" }}-{{ checksum "gradle/*" }}
       - run:
           command: ./gradlew build
           no_output_timeout: 30m
@@ -33,8 +33,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "build.gradle.kts" }}
-            - v3-dependencies-
+            - v4-dependencies-{{ checksum "build.gradle.kts" }}-{{ checksum "gradle/*" }}
+            - v4-dependencies-
       - run: ./gradlew release
       - run: ./gradlew publish
 workflows:


### PR DESCRIPTION
Reduce the size of the CI cache.
When you update dependency locks without changing `build.gradle.kts`, your `~/.gradle` will grow.
In order to discard old dependencies, include locks in cache keys.