### PR TITLE
JPERF-730: Bump commons-codec, so that the module is compatible with …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/virtual-users/compare/release-3.13.0...master
 
+### Fixed
+- Make the module's dependencies compatible with recent versions of aws-resources (1.7.x). Unblock [JPERF-730].
+
 ## [3.13.0] - 2020-11-17
 [3.13.0]: https://github.com/atlassian/virtual-users/compare/release-3.12.0...release-3.13.0
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ configurations.all {
         failOnVersionConflict()
         eachDependency {
             when (requested.module.toString()) {
-                "commons-codec:commons-codec" -> useVersion("1.10")
+                "commons-codec:commons-codec" -> useVersion("1.11")
                 "com.google.code.gson:gson" -> useVersion("2.8.2")
                 "org.slf4j:slf4j-api" -> useVersion("1.8.0-alpha2")
                 "com.google.code.findbugs:jsr305" -> useVersion("1.3.9")
@@ -48,7 +48,7 @@ configurations.all {
         if (name.startsWith("test")) {
             eachDependency {
                 when (requested.module.toString()) {
-                    "org.apache.httpcomponents:httpclient" -> useVersion("4.5.5")
+                    "org.apache.httpcomponents:httpclient" -> useVersion("4.5.13")
                     "org.codehaus.plexus:plexus-utils" -> useVersion("3.1.0")
                     "org.jsoup:jsoup" -> useVersion("1.10.2")
                     "commons-io:commons-io" -> useVersion("2.6")

--- a/gradle/dependency-locks/apiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/apiDependenciesMetadata.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:jira-actions:3.13.4
+com.atlassian.performance.tools:jira-actions:3.16.2
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,9 +4,9 @@
 com.atlassian.data:random-data:1.4.3
 com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.13.4
-com.atlassian.performance.tools:jira-software-actions:1.3.3
-com.atlassian.performance.tools:jvm-tasks:1.2.0
+com.atlassian.performance.tools:jira-actions:3.16.2
+com.atlassian.performance.tools:jira-software-actions:1.3.4
+com.atlassian.performance.tools:jvm-tasks:1.2.1
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
@@ -18,7 +18,7 @@ com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 com.typesafe:config:1.2.1
 commons-cli:commons-cli:1.4
-commons-codec:commons-codec:1.10
+commons-codec:commons-codec:1.11
 commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -4,9 +4,9 @@
 com.atlassian.data:random-data:1.4.3
 com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.13.4
-com.atlassian.performance.tools:jira-software-actions:1.3.3
-com.atlassian.performance.tools:jvm-tasks:1.2.0
+com.atlassian.performance.tools:jira-actions:3.16.2
+com.atlassian.performance.tools:jira-software-actions:1.3.4
+com.atlassian.performance.tools:jvm-tasks:1.2.1
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
@@ -18,7 +18,7 @@ com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 com.typesafe:config:1.2.1
 commons-cli:commons-cli:1.4
-commons-codec:commons-codec:1.10
+commons-codec:commons-codec:1.11
 commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -4,9 +4,9 @@
 com.atlassian.data:random-data:1.4.3
 com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.13.4
-com.atlassian.performance.tools:jira-software-actions:1.3.3
-com.atlassian.performance.tools:jvm-tasks:1.2.0
+com.atlassian.performance.tools:jira-actions:3.16.2
+com.atlassian.performance.tools:jira-software-actions:1.3.4
+com.atlassian.performance.tools:jvm-tasks:1.2.1
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
@@ -18,7 +18,7 @@ com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 com.typesafe:config:1.2.1
 commons-cli:commons-cli:1.4
-commons-codec:commons-codec:1.10
+commons-codec:commons-codec:1.11
 commons-io:commons-io:2.5
 commons-logging:commons-logging:1.2
 io.github.bonigarcia:webdrivermanager:1.7.1

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -6,10 +6,10 @@ com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:docker-infrastructure:0.3.3
 com.atlassian.performance.tools:infrastructure:4.15.0
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.13.4
-com.atlassian.performance.tools:jira-software-actions:1.3.3
-com.atlassian.performance.tools:jvm-tasks:1.2.0
-com.atlassian.performance.tools:ssh:2.3.1
+com.atlassian.performance.tools:jira-actions:3.16.2
+com.atlassian.performance.tools:jira-software-actions:1.3.4
+com.atlassian.performance.tools:jvm-tasks:1.2.1
+com.atlassian.performance.tools:ssh:2.4.0
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.fasterxml.jackson.core:jackson-core:2.10.3
@@ -30,7 +30,7 @@ com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 com.typesafe:config:1.2.1
 commons-cli:commons-cli:1.4
-commons-codec:commons-codec:1.10
+commons-codec:commons-codec:1.11
 commons-io:commons-io:2.6
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
@@ -44,8 +44,8 @@ org.apache.commons:commons-csv:1.3
 org.apache.commons:commons-exec:1.3
 org.apache.commons:commons-lang3:3.5
 org.apache.commons:commons-math3:3.6.1
-org.apache.httpcomponents:httpclient:4.5.5
-org.apache.httpcomponents:httpcore:4.4.9
+org.apache.httpcomponents:httpclient:4.5.13
+org.apache.httpcomponents:httpcore:4.4.13
 org.apache.logging.log4j:log4j-api:2.10.0
 org.apache.logging.log4j:log4j-core:2.10.0
 org.apache.logging.log4j:log4j-jul:2.10.0

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -6,10 +6,10 @@ com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:docker-infrastructure:0.3.3
 com.atlassian.performance.tools:infrastructure:4.15.0
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.13.4
-com.atlassian.performance.tools:jira-software-actions:1.3.3
-com.atlassian.performance.tools:jvm-tasks:1.2.0
-com.atlassian.performance.tools:ssh:2.3.1
+com.atlassian.performance.tools:jira-actions:3.16.2
+com.atlassian.performance.tools:jira-software-actions:1.3.4
+com.atlassian.performance.tools:jvm-tasks:1.2.1
+com.atlassian.performance.tools:ssh:2.4.0
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.fasterxml.jackson.core:jackson-core:2.10.3
@@ -30,7 +30,7 @@ com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 com.typesafe:config:1.2.1
 commons-cli:commons-cli:1.4
-commons-codec:commons-codec:1.10
+commons-codec:commons-codec:1.11
 commons-io:commons-io:2.6
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
@@ -44,8 +44,8 @@ org.apache.commons:commons-csv:1.3
 org.apache.commons:commons-exec:1.3
 org.apache.commons:commons-lang3:3.5
 org.apache.commons:commons-math3:3.6.1
-org.apache.httpcomponents:httpclient:4.5.5
-org.apache.httpcomponents:httpcore:4.4.9
+org.apache.httpcomponents:httpclient:4.5.13
+org.apache.httpcomponents:httpcore:4.4.13
 org.apache.logging.log4j:log4j-api:2.10.0
 org.apache.logging.log4j:log4j-core:2.10.0
 org.apache.logging.log4j:log4j-jul:2.10.0

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -6,10 +6,10 @@ com.atlassian.performance.tools:concurrency:1.1.0
 com.atlassian.performance.tools:docker-infrastructure:0.3.3
 com.atlassian.performance.tools:infrastructure:4.15.0
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.13.4
-com.atlassian.performance.tools:jira-software-actions:1.3.3
-com.atlassian.performance.tools:jvm-tasks:1.2.0
-com.atlassian.performance.tools:ssh:2.3.1
+com.atlassian.performance.tools:jira-actions:3.16.2
+com.atlassian.performance.tools:jira-software-actions:1.3.4
+com.atlassian.performance.tools:jvm-tasks:1.2.1
+com.atlassian.performance.tools:ssh:2.4.0
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.fasterxml.jackson.core:jackson-core:2.10.3
@@ -30,7 +30,7 @@ com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 com.typesafe:config:1.2.1
 commons-cli:commons-cli:1.4
-commons-codec:commons-codec:1.10
+commons-codec:commons-codec:1.11
 commons-io:commons-io:2.6
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
@@ -45,8 +45,8 @@ org.apache.commons:commons-csv:1.3
 org.apache.commons:commons-exec:1.3
 org.apache.commons:commons-lang3:3.5
 org.apache.commons:commons-math3:3.6.1
-org.apache.httpcomponents:httpclient:4.5.5
-org.apache.httpcomponents:httpcore:4.4.9
+org.apache.httpcomponents:httpclient:4.5.13
+org.apache.httpcomponents:httpcore:4.4.13
 org.apache.logging.log4j:log4j-api:2.10.0
 org.apache.logging.log4j:log4j-core:2.10.0
 org.apache.logging.log4j:log4j-jul:2.10.0


### PR DESCRIPTION
…recent versions of aws-resources (1.7.x)

Compatibility with aws-resources was broken with https://bitbucket.org/atlassian/aws-resources/commits/6e272c387f3dd60b44a0d4dfd019ae98b559a6a8 (version 1.6.1).

We also had to bump httpclient, because the older version was depending on commons-codec 1.10.