### PR TITLE
JCES-2186: Log applyLoad failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/virtual-users/compare/release-3.13.0...master
 
+### Fixed
+- Log `applyLoad` failures
+
 ## [3.13.0] - 2020-11-17
 [3.13.0]: https://github.com/atlassian/virtual-users/compare/release-3.12.0...release-3.13.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/virtualusers/LoadTest.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/virtualusers/LoadTest.kt
@@ -137,7 +137,16 @@ internal class LoadTest(
         logger.info("Segmenting load across $userCount VUs")
         val segments = users.mapIndexed { index, user -> segmentLoad(user, index + 1) }
         logger.info("Load segmented")
-        segments.forEach { loadPool.submit { applyLoad(it) } }
+        segments.forEach {
+            loadPool.submit {
+                try {
+                    applyLoad(it)
+                } catch (e: Exception) {
+                    logger.error("Failed to apply load", e)
+                    throw e
+                }
+            }
+        }
         Thread.sleep(finish.toMillis())
         close(segments)
     }


### PR DESCRIPTION
We gather logs from failed actions, but if something happens before
we start to execute actions (for example, during LogInAction),
the segment will fail silently without logging any exception.